### PR TITLE
Change: Set required permissions for convention commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,10 @@ name: Conventional Commits
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   conventional-commits:
     name: Conventional Commits


### PR DESCRIPTION


## What

Set required permissions for convention commits workflow

## Why

The workflow requires write permissions to create comments in a pull request and read permissions to the contents of the repository.